### PR TITLE
test: Cover all functionality with tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-application-import-names = pre_commit_which
+application-import-names = pre_commit_run_hook_entry
 import-order-style = smarkets
 inline-quotes = double
 max-complexity = 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: ["master"]
 
 env:
+  COVERALLS_VERSION: "2.0.0"
   DEV_PYTHON_VERSION: "3.8"
   POETRY_VERSION: "1.0.9"
   TWINE_VERSION: "3.1.1"
@@ -46,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8"]
 
     runs-on: "ubuntu-latest"
 
@@ -67,7 +68,7 @@ jobs:
         run: |
           poetry config --local virtualenvs.create true
           poetry config --local virtualenvs.in-project true
-          poetry install --no-dev
+          poetry install
 
       - name: "Cache pre-commit"
         if: "matrix.python-version == env.DEV_PYTHON_VERSION"
@@ -79,6 +80,18 @@ jobs:
       - name: "Run pre-commit"
         if: "matrix.python-version == env.DEV_PYTHON_VERSION"
         uses: "pre-commit/action@v1.0.1"
+
+      - name: "Run tests"
+        if: "matrix.python-version == env.DEV_PYTHON_VERSION"
+        run: "poetry run python -m pytest --cov --no-cov-on-fail"
+
+      - name: "Send report to coveralls"
+        if: "matrix.python-version == env.DEV_PYTHON_VERSION"
+        env:
+          COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
+        run: |
+          python -m pip install coveralls==${{ env.COVERALLS_VERSION }}
+          python -m coveralls
 
   package:
     needs: "test"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 POETRY ?= poetry
 PRE_COMMIT ?= pre-commit
+PYTHON ?= $(POETRY) run python
 
 install: .install
 .install: pyproject.toml poetry.lock
@@ -15,4 +16,4 @@ lint-only:
 
 test: lint test-only
 test-only:
-	echo "All OK!"
+	$(PYTHON) -m pytest --cov --no-cov-on-fail

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,10 @@ pre-commit-run-hook-entry
     :target: https://github.com/playpauseandstop/pre-commit-run-hook-entry/blob/master/LICENSE
     :alt: BSD License
 
+.. image:: https://coveralls.io/repos/playpauseandstop/pre-commit-run-hook-entry/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/playpauseandstop/pre-commit-run-hook-entry
+    :alt: Coverage
+
 Run `pre-commit`_ hook entry. Allow to run pre-commit hooks for text editor
 formatting / linting needs.
 
@@ -34,7 +38,7 @@ formatting / linting needs.
 Requirements
 ============
 
-- `Python <https://www.python.org/>`_ 3.6.1 or later
+- `Python <https://www.python.org/>`_ 3.7 or later
 - `pre-commit`_ 2.4.0 or later
 
 License

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,12 +7,60 @@ python-versions = "*"
 version = "1.4.4"
 
 [[package]]
+category = "dev"
+description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
+
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+
+[[package]]
 category = "main"
 description = "Validate configuration and produce human readable error messages."
 name = "cfgv"
 optional = false
 python-versions = ">=3.6.1"
 version = "3.1.0"
+
+[[package]]
+category = "dev"
+description = "Cross-platform colored terminal text."
+marker = "sys_platform == \"win32\""
+name = "colorama"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
+
+[[package]]
+category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.1"
+
+[package.dependencies]
+[package.dependencies.toml]
+optional = true
+version = "*"
+
+[package.extras]
+toml = ["toml"]
 
 [[package]]
 category = "main"
@@ -48,35 +96,22 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "importlib-resources"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "main"
-description = "Read resources from Python packages"
-marker = "python_version < \"3.7\""
-name = "importlib-resources"
+category = "dev"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.5.0"
-
-[package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
-[package.dependencies.zipp]
-python = "<3.8"
-version = ">=0.4"
-
-[package.extras]
-docs = ["sphinx", "rst.linker", "jaraco.packaging"]
+python-versions = ">=3.5"
+version = "8.3.0"
 
 [[package]]
 category = "main"
@@ -87,12 +122,40 @@ python-versions = "*"
 version = "1.4.0"
 
 [[package]]
+category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.4"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+six = "*"
+
+[[package]]
+category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
 category = "main"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 name = "pre-commit"
 optional = false
 python-versions = ">=3.6.1"
-version = "2.4.0"
+version = "2.5.1"
 
 [package.dependencies]
 cfgv = ">=2.0.0"
@@ -106,9 +169,62 @@ virtualenv = ">=20.0.8"
 python = "<3.8"
 version = "*"
 
-[package.dependencies.importlib-resources]
-python = "<3.7"
-version = "*"
+[[package]]
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.8.1"
+
+[[package]]
+category = "dev"
+description = "Python parsing module"
+name = "pyparsing"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
+
+[[package]]
+category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+python-versions = ">=3.5"
+version = "5.4.3"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = "*"
+more-itertools = ">=4.0.0"
+packaging = "*"
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+wcwidth = "*"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+checkqa-mypy = ["mypy (v0.761)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.9.0"
+
+[package.dependencies]
+coverage = ">=4.4"
+pytest = ">=3.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 category = "main"
@@ -152,13 +268,17 @@ six = ">=1.9.0,<2"
 python = "<3.8"
 version = ">=0.12,<2"
 
-[package.dependencies.importlib-resources]
-python = "<3.7"
-version = ">=1.0,<2"
-
 [package.extras]
 docs = ["sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2)"]
 testing = ["pytest (>=4)", "coverage (>=5)", "coverage-enable-subprocess (>=1)", "pytest-xdist (>=1.31.0)", "pytest-mock (>=2)", "pytest-env (>=0.6.2)", "pytest-randomly (>=1)", "pytest-timeout", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+
+[[package]]
+category = "dev"
+description = "Measures the displayed width of unicode strings in a terminal"
+name = "wcwidth"
+optional = false
+python-versions = "*"
+version = "0.2.4"
 
 [[package]]
 category = "main"
@@ -174,17 +294,62 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "9f0db1301f75ac875d6f7463b337ce4b52b2297e2bf67b027f2310a58fd88019"
-python-versions = ">=3.6.1"
+content-hash = "89ef62adabe104b98c4aa68c1c6f6d708c54aeebb15039bbc121e09b926a6aaf"
+python-versions = "^3.7"
 
 [metadata.files]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
 cfgv = [
     {file = "cfgv-3.1.0-py2.py3-none-any.whl", hash = "sha256:1ccf53320421aeeb915275a196e23b3b8ae87dea8ac6698b1638001d4a486d53"},
     {file = "cfgv-3.1.0.tar.gz", hash = "sha256:c8e8f552ffcc6194f4e18dd4f68d9aef0c0d58ae7e7be8c82bee3c5e9edfa513"},
+]
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+coverage = [
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 distlib = [
     {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
@@ -198,19 +363,43 @@ identify = [
     {file = "identify-1.4.19.tar.gz", hash = "sha256:249ebc7e2066d6393d27c1b1be3b70433f824a120b1d8274d362f1eb419e3b52"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
-    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+    {file = "importlib_metadata-1.6.1-py2.py3-none-any.whl", hash = "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"},
+    {file = "importlib_metadata-1.6.1.tar.gz", hash = "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545"},
 ]
-importlib-resources = [
-    {file = "importlib_resources-1.5.0-py2.py3-none-any.whl", hash = "sha256:85dc0b9b325ff78c8bef2e4ff42616094e16b98ebd5e3b50fe7e2f0bbcdcde49"},
-    {file = "importlib_resources-1.5.0.tar.gz", hash = "sha256:6f87df66833e1942667108628ec48900e02a4ab4ad850e25fbf07cb17cf734ca"},
+more-itertools = [
+    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
+    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
 ]
 nodeenv = [
     {file = "nodeenv-1.4.0-py2.py3-none-any.whl", hash = "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"},
 ]
+packaging = [
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
 pre-commit = [
-    {file = "pre_commit-2.4.0-py2.py3-none-any.whl", hash = "sha256:5559e09afcac7808933951ffaf4ff9aac524f31efbc3f24d021540b6c579813c"},
-    {file = "pre_commit-2.4.0.tar.gz", hash = "sha256:703e2e34cbe0eedb0d319eff9f7b83e2022bb5a3ab5289a6a8841441076514d0"},
+    {file = "pre_commit-2.5.1-py2.py3-none-any.whl", hash = "sha256:c5c8fd4d0e1c363723aaf0a8f9cba0f434c160b48c4028f4bae6d219177945b3"},
+    {file = "pre_commit-2.5.1.tar.gz", hash = "sha256:da463cf8f0e257f9af49047ba514f6b90dbd9b4f92f4c8847a3ccd36834874c7"},
+]
+py = [
+    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
+    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
+    {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.9.0.tar.gz", hash = "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322"},
+    {file = "pytest_cov-2.9.0-py2.py3-none-any.whl", hash = "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -236,6 +425,10 @@ toml = [
 virtualenv = [
     {file = "virtualenv-20.0.21-py2.py3-none-any.whl", hash = "sha256:a730548b27366c5e6cbdf6f97406d861cccece2e22275e8e1a757aeff5e00c70"},
     {file = "virtualenv-20.0.21.tar.gz", hash = "sha256:a116629d4e7f4d03433b8afa27f43deba09d48bc48f5ecefa4f015a178efb6cf"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.4-py2.py3-none-any.whl", hash = "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f"},
+    {file = "wcwidth-0.2.4.tar.gz", hash = "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pre-commit-run-hook-entry.sublime-project
+++ b/pre-commit-run-hook-entry.sublime-project
@@ -3,6 +3,7 @@
 	[
 		{
             "file_exclude_patterns": [
+                ".coverage*",
                 ".install",
                 "poetry.lock"
             ],

--- a/pre_commit_run_hook_entry.py
+++ b/pre_commit_run_hook_entry.py
@@ -80,18 +80,6 @@ def find_hook(args: argparse.Namespace, store: Store) -> Hook:
 
 
 def get_args(argv: Argv) -> Tuple[str, Argv]:
-    """
-    >>> get_args(["black"])
-    ("black", [])
-    >>> get_args(["mypy", "+"])
-    ("mypy", ["+"])
-    >>> get_args(["black", "--", "--diff", "--quiet", "file.py"])
-    ("black", ["--diff", "--quiet", "file.py"])
-    >>> get_args(["--diff", "--quiet", "file.py", "--", "black"])
-    ("black", ["--diff", "--quiet", "file.py"])
-    >>> get_args(["--format", "default", "--", "flake8", "-"])
-    ("flake8", ["--format", "default", "-"])
-    """
     if ARG_BREAK not in argv:
         return (argv[0], argv[1:])
 
@@ -100,7 +88,7 @@ def get_args(argv: Argv) -> Tuple[str, Argv]:
         return (argv[0], argv[2:])
 
     next_idx = idx + 2
-    return (argv[idx + 1], (*argv[:idx], *argv[next_idx:]))
+    return (argv[idx + 1], [*argv[:idx], *argv[next_idx:]])
 
 
 def get_pre_commit_args(
@@ -240,5 +228,5 @@ def usage() -> int:
     return 1
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,18 @@
 [tool.black]
 line_length = 79
 
+[tool.coverage.run]
+branch = true
+source = ["pre_commit_run_hook_entry"]
+
+[tool.coverage.paths]
+source = ["pre_commit_run_hook_entry.py"]
+
+[tool.coverage.report]
+fail_under = 85
+skip_covered = true
+show_missing = true
+
 [tool.poetry]
 name = "pre-commit-run-hook-entry"
 version = "1.0.0a1"
@@ -23,10 +35,13 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6.1"
+python = "^3.7"
 pre-commit = "^2.4.0"
 
 [tool.poetry.dev-dependencies]
+coverage = {extras = ["toml"], version = "^5.1"}
+pytest = "^5.4.3"
+pytest-cov = "^2.9.0"
 
 [tool.poetry.scripts]
 pre-commit-run-black-entry = "pre_commit_run_hook_entry:main_black"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = tests.py

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,151 @@
+import os
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from random import choice
+from string import ascii_letters, digits
+from typing import Iterator
+
+import pytest
+
+from pre_commit_run_hook_entry import find_file, get_args, get_pre_commit_args
+
+
+ROOT_PATH = (Path(__file__).parent).absolute()
+
+
+@contextmanager
+def chdir(path: Path) -> Iterator[Path]:
+    cwd = Path.cwd()
+    try:
+        yield os.chdir(path)
+    finally:
+        os.chdir(cwd)
+
+
+def test_find_file():
+    workflows_path = ROOT_PATH / ".github" / "workflows"
+    with chdir(workflows_path):
+        assert find_file("ci.yml") == workflows_path / "ci.yml"
+        assert find_file("pyproject.toml") == ROOT_PATH / "pyproject.toml"
+
+
+def test_find_file_does_not_exist():
+    prefix = "".join(choice(ascii_letters) for _ in range(16))
+    suffix = "".join(choice(digits) for _ in range(8))
+    file_name = f"{prefix}_{suffix}"
+    assert find_file(file_name) is None
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    (
+        (["--help"], ("--help", [])),
+        (["black"], ("black", [])),
+        (["mypy", "file.py"], ("mypy", ["file.py"])),
+        (
+            ["black", "--", "--diff", "--quiet", "file.py"],
+            ("black", ["--diff", "--quiet", "file.py"]),
+        ),
+        (
+            ["--format", "default", "--", "flake8", "-"],
+            ("flake8", ["--format", "default", "-"]),
+        ),
+    ),
+)
+def test_get_args(args, expected):
+    assert get_args(args) == expected
+
+
+def test_get_pre_commit_args_default():
+    args = get_pre_commit_args("black")
+    assert args.hook == "black"
+    assert args.config == ".pre-commit-config.yaml"
+
+
+def test_get_pre_commmit_args_with_config():
+    config_yaml = ROOT_PATH / ".pre-commit-config.yaml"
+    args = get_pre_commit_args("black", config=config_yaml)
+    assert args.config == str(config_yaml)
+
+
+def test_pre_commit_run_black_entry():
+    result = subprocess.run(
+        [
+            "pre-commit-run-black-entry",
+            "--check",
+            "pre_commit_run_hook_entry.py",
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == b""
+    assert result.stderr == b""
+
+
+def test_pre_commit_run_black_entry_stdin(tmp_path):
+    sample = tmp_path / "file.py"
+    sample.write_text('print("Hello, world")\n')
+
+    with open(sample, "rb") as handler:
+        result = subprocess.run(
+            ["pre-commit-run-black-entry", "-"],
+            stdin=handler,
+            capture_output=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == b'print("Hello, world")\n'
+        assert result.stderr == b""
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ["black", "--", "--check", "pre_commit_run_hook_entry.py"],
+        ["flake8", "--", "pre_commit_run_hook_entry.py"],
+        ["mypy", "--", "pre_commit_run_hook_entry.py"],
+        ["check-toml", "--", "pyproject.toml"],
+        ["check-yaml", "--", ".pre-commit-config.yaml"],
+        ["rstcheck", "--", "README.rst"],
+    ),
+)
+def test_pre_commit_run_hook_entry(args):
+    assert subprocess.check_call(["pre-commit-run-hook-entry", *args]) == 0
+
+
+def test_pre_commit_run_hook_entry_error():
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(
+            ["pre-commit-run-hook-entry", "does-not-exist", "--", "README.rst"]
+        )
+
+
+def test_pre_commit_run_hook_entry_stdin(tmp_path):
+    sample = tmp_path / "file.py"
+    sample.write_text('print("Hello, world!")\n')
+
+    with open(sample, "rb") as handler:
+        assert (
+            subprocess.check_call(
+                [
+                    "pre-commit-run-hook-entry",
+                    "black",
+                    "--",
+                    "--check",
+                    "--diff",
+                    "-",
+                ],
+                stdin=handler,
+            )
+            == 0
+        )
+
+
+@pytest.mark.parametrize("args", ([], ["--help"]))
+def test_pre_commit_run_hook_entry_usage(args):
+    result = subprocess.run(
+        ["pre-commit-run-hook-entry", *args], capture_output=True
+    )
+    assert result.returncode == 1
+    assert result.stdout == b""
+    assert result.stderr == b"Usage: pre-commit-run-hook-entry HOOK ...\n"


### PR DESCRIPTION
Ensure that `pre-commit-run-hook-entry` as well as `pre-commit-run-black-entry` works as expected.

Which means to ensure that library supports all pre-commit hooks enabled for the repo, especially:

- `black` for Python files formatting
- `flake8` & `mypy` for Python files linting