### PR TITLE
feat: Provide pre-commit-which-hook-entry script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 1.0.0 (In Development)
 ======================
 
+1.0.0a2 (In Development)
+------------------------
+
+**Features:**
+
+- Mark this script dangerous to use cause of `pre-commit/pre-commit#1468
+  <https://github.com/pre-commit/pre-commit/issues/1468#issuecomment-640699437>`_
+- Implement ``pre-commit-which-hook-entry`` script for finding out full path
+  of hook entry script
+
 1.0.0a1 (2020-06-11)
 --------------------
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PYTHON ?= $(POETRY) run python
 
 install: .install
 .install: pyproject.toml poetry.lock
+	$(POETRY) config --local virtualenvs.create true
 	$(POETRY) config --local virtualenvs.in-project true
 	$(POETRY) install
 	touch $@

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,16 @@ formatting / linting needs.
 
 .. _`pre-commit`: https://pre-commit.com/
 
+Danger Zone
+===========
+
+**IMPORTANT:** This is highly experimental tool as `pre-commit internals does
+not intend to be used in other scripts
+<https://github.com/pre-commit/pre-commit/issues/1468#issuecomment-640699437>`_.
+It might be broken after new pre-commit release.
+
+**TO USE WITH CAUTION!**
+
 Requirements
 ============
 
@@ -59,7 +69,8 @@ Usage
 
 .. code-block:: bash
 
-    pre-commit-run-hook-entry HOOK
+    pre-commit-run-hook-entry HOOK [ARGS]
+    pre-commit-which-hook-entry HOOK
 
 Prerequisites
 -------------
@@ -106,8 +117,8 @@ pre-commit integration, but it seems do not respect settings from
     }
 
 
-SublimeLinter-contrib-flake8
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SublimeLinter-flake8
+~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
 
@@ -126,6 +137,49 @@ SublimeLinter-contrib-mypy
         "SublimeLinter.linters.mypy.executable": "pre-commit-run-hook-entry",
         "SublimeLinter.linters.mypy.args": ["--", "mypy"]
     }
+
+SublimeJsPrettier
+~~~~~~~~~~~~~~~~~
+
+First, you need to find out path to prettier hook entry with,
+
+.. code-block:: bash
+
+    pre-commit-which-hook-entry prettier
+
+Then, paste command output (``<OUTPUT>``) into plugin config,
+
+.. code-block:: json
+
+    {
+        "js_prettier": {
+            "prettier_cli_path": "<OUTPUT>"
+        }
+    }
+
+SublimeLinter-eslint
+~~~~~~~~~~~~~~~~~~~~
+
+First, you need to find out path to eslint hook entry with,
+
+.. code-block:: bash
+
+    pre-commit-which-hook-entry eslint
+
+Then, paste command output (``<OUTPUT>``) into plugin config,
+
+.. code-block:: json
+
+    {
+        "SublimeLinter.linters.eslint.executable": "<OUTPUT>",
+        "SublimeLinter.linters.eslint.env": {
+            "NODE_PATH": "<OUTPUT>/../../lib/node_modules"
+        }
+    }
+
+**IMPORTANT:** If you're using any ``additionalDependencies`` for eslint hook,
+you need to configure ``NODE_PATH``, so plugin will be able to find out given
+dependencies.
 
 Issues & Feature Requests
 =========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ show_missing = true
 
 [tool.poetry]
 name = "pre-commit-run-hook-entry"
-version = "1.0.0a1"
+version = "1.0.0a2"
 description = "Run pre-commit hook entry. Allow to run pre-commit hooks for text editor formatting / linting needs."
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"
@@ -46,6 +46,7 @@ pytest-cov = "^2.9.0"
 [tool.poetry.scripts]
 pre-commit-run-black-entry = "pre_commit_run_hook_entry:main_black"
 pre-commit-run-hook-entry = "pre_commit_run_hook_entry:main"
+pre-commit-which-hook-entry = "pre_commit_run_hook_entry:main_which"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/playpauseandstop/pre-commit-run-hook-entry/issues"

--- a/tests.py
+++ b/tests.py
@@ -149,3 +149,21 @@ def test_pre_commit_run_hook_entry_usage(args):
     assert result.returncode == 1
     assert result.stdout == b""
     assert result.stderr == b"Usage: pre-commit-run-hook-entry HOOK ...\n"
+
+
+def test_pre_commit_which_hook_entry():
+    result = subprocess.run(
+        ["pre-commit-which-hook-entry", "black"], capture_output=True
+    )
+    assert result.returncode == 0
+    assert result.stdout.endswith(b"/black\n")
+    assert result.stderr == b""
+
+
+def test_pre_commit_which_hook_entry_does_not_exist():
+    result = subprocess.run(
+        ["pre-commit-which-hook-entry", "eslint"], capture_output=True
+    )
+    assert result.returncode == 1
+    assert result.stdout.startswith(b"An unexpected error has occurred: ")
+    assert result.stderr == b""


### PR DESCRIPTION
This script is useful for cases when text editor plugin is not able to use run hook entry script, but it allows to provide full path to the tool, such as eslint or prettier.

Also mark the script as dangerous to use cause of fact that pre-commit internals does not intend to be used in external scripts.

Fixes: #3
Fixes: #4
Fixes: #8