### PR TITLE
ci: Update default branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: "ci"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
     tags: ["v*"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 env:
   PYTHONUNBUFFERED: "1"

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: "actions/checkout@v3.0.1"
+      - uses: "actions/checkout@v3.0.2"
         with:
           ref: "main"
 

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@ pre-commit-run-hook-entry
     :alt: Python versions
 
 .. image:: https://img.shields.io/pypi/l/pre-commit-run-hook-entry.svg
-    :target: https://github.com/playpauseandstop/pre-commit-run-hook-entry/blob/master/LICENSE
+    :target: https://github.com/playpauseandstop/pre-commit-run-hook-entry/blob/main/LICENSE
     :alt: BSD License
 
-.. image:: https://coveralls.io/repos/playpauseandstop/pre-commit-run-hook-entry/badge.svg?branch=master&service=github
+.. image:: https://coveralls.io/repos/playpauseandstop/pre-commit-run-hook-entry/badge.svg?branch=main&service=github
     :target: https://coveralls.io/github/playpauseandstop/pre-commit-run-hook-entry
     :alt: Coverage
 


### PR DESCRIPTION
To use `main` instead of `master` in CI workflows and docs.