### PR TITLE
ci: Disable attestations on publishing to PyPI from reusable workflow

### DIFF
--- a/.github/workflows/ci_package.yml
+++ b/.github/workflows/ci_package.yml
@@ -35,3 +35,5 @@ jobs:
       - name: "Publish package"
         if: "${{ startsWith(github.ref, 'refs/tags/') }}"
         uses: "pypa/gh-action-pypi-publish@v1.12.3"
+        with:
+          attestations: false  # Disable attestations until publishing to PyPI from reusable workflow will be fixed


### PR DESCRIPTION
Related: https://github.com/pypa/gh-action-pypi-publish/issues/283
